### PR TITLE
Change SQL API from mysql to mysqli to support PHP7 on Ubuntu 16.04

### DIFF
--- a/core.php
+++ b/core.php
@@ -1,65 +1,64 @@
 <?PHP
-include_once '../cas/CAS.php';
-phpCAS::client(CAS_VERSION_2_0,'cas-auth.rpi.edu',443,'/cas/');
-phpCAS::setCasServerCACert("../cas/CACert.pem");
-
-class QuickLogs {
-
-	public static function db_connect()
-	{
-		mysql_connect("localhost", "QuickLogs", "6BU44XjpTmXnCaQD") or die("Could Not Connect To MYSQL");
-		mysql_select_db("QuickLogs") or die ("Could Not Connect to DATABASE");
+	include_once '../cas/CAS.php';
+	phpCAS::client(CAS_VERSION_2_0,'cas-auth.rpi.edu',443,'/cas/');
+	phpCAS::setCasServerCACert("../cas/CACert.pem");
+	
+	class QuickLogs {
+	
+		public static function db_connect()
+		{
+		 return mysqli_connect("localhost", "database_user", "database_password", "database_name") or die("Could Not Connect To MYSQL or DATABASE");
+		}
+		
+		public static function db_disconnect($mysqli)
+		{
+		 mysqli_close($mysqli);
+		}
+		
+		public static function get_version()
+		{
+			return "3.3.4";
+		}
+		
 	}
 	
-	public static function db_disconnect()
-	{
-		mysql_close();
+	class database_helper{
+		//This is added part way through 3.3.0, some code will use some will not
+		public static function db_return_array($passed_query)
+			{
+				$mysqli = mysqli_connect("localhost", "root", "bacon", "QuickLogs") or die("Could Not Connect To MYSQL or DATABASE");
+				$return_array = array();
+				//echo $query;
+				$main_result = mysqli_query($mysqli, $passed_query);
+				if ($main_result)
+				{
+					while($main_row = mysqli_fetch_array($main_result))
+					{
+						array_push($return_array, $main_row);
+					}
+					return $return_array;
+				}else{
+					echo "Error with " . $passed_query;
+					return $return_array;
+				}
+			}
+			
+			//Another wrapper but for a insert comamnd
+			public static function db_insert_query($passed_query)
+			{
+				$mysqli = mysqli_connect("localhost", "root", "bacon", "QuickLogs") or die("Could Not Connect To MYSQL or DATABASE");
+				$result = mysqli_query($mysqli, $passed_query);
+				if ($result)
+				{
+					return mysqli_insert_id($mysqli);
+				}else{
+					echo "Error on inset " . $passed_query;
+					return false;
+				}
+			}
 	}
 	
-	public static function get_version()
-	{
-		return "3.3.4";
-	}
 	
-}
-
-class database_helper{
-	//This is added part way through 3.3.0, some code will use some will not
-	public static function db_return_array($passed_query)
-        {
-            QuickLogs::db_connect();
-            $return_array = array();
-            //echo $query;
-            $main_result = mysql_query($passed_query);
-            if ($main_result)
-            {
-                while($main_row = mysql_fetch_array($main_result))
-                {
-                    array_push($return_array, $main_row);
-                }
-                return $return_array;
-            }else{
-                echo "Error with " . $passed_query;
-                return $return_array;
-            }
-        }
-        
-        //Another wrapper but for a insert comamnd
-        public static function db_insert_query($passed_query)
-        {
-            QuickLogs::db_connect();
-            $result = mysql_query($passed_query);
-            if ($result)
-            {
-                return mysql_insert_id();
-            }else{
-                echo "Error on inset " . $passed_query;
-                return false;
-            }
-        }
-}
-
-
-QuickLogs::db_connect();
-
-?>
+	$mysqli = mysqli_connect("localhost", "root", "bacon", "QuickLogs") or die("Could Not Connect To MYSQL or DATABASE");
+	
+	?>

--- a/index.php
+++ b/index.php
@@ -1,5 +1,4 @@
-<?PHP header("location: ./lite/");
-// Dan Berkowitz, berkod2@rpi.edu, dansberkowitz@gmail.com, Feb 2012
-
-
- ?>
+<?PHP header("location: ./lite/login.php");
+	// Dan Berkowitz, berkod2@rpi.edu, dansberkowitz@gmail.com, Feb 2012
+	// Updated from PHP 5 to PHP 7, Joshua Rosenfeld, rosenj5@rpi.edu, jomaxro@gmail.com, Jan 2017
+?>

--- a/lite/change.php
+++ b/lite/change.php
@@ -1,12 +1,13 @@
 <?PHP
 	// Dan Berkowitz, berkod2@rpi.edu, dansberkowitz@gmail.com, Feb 2012
+	// Updated from PHP 5 to PHP 7, Joshua Rosenfeld, rosenj5@rpi.edu, jomaxro@gmail.com, Jan 2017
 	//Here we are changing some of the options for what options are allowed, this is a admin only panel, but the security for it is really anyone who knows and has authenticated. We are honor systeming it mostly.
 	include '../core.php';
-	
+	$mysqli = mysqli_connect("localhost", "root", "bacon", "QuickLogs") or die("Could Not Connect To MYSQL or DATABASE");
 	//Submitting for disabling a option,
 	if(phpCAS::isAuthenticated() AND isset($_REQUEST['Part']) AND isset($_REQUEST['Change_To']))
 	{
-		$result = mysql_query("UPDATE `QuickLogs`.`Types` SET `disabled` ='" . $_REQUEST['Change_To'] . "' WHERE `index`='" . $_REQUEST['Part'] . "'");
+		$result = mysqli_query($mysqli, "UPDATE `QuickLogs`.`Types` SET `disabled` ='" . $_REQUEST['Change_To'] . "' WHERE `index`='" . $_REQUEST['Part'] . "'");
 		echo "UPDATE `QuickLogs`.`Types` SET `disabled` ='" . $_REQUEST['Change_To'] . "' WHERE `index`='" . $_REQUEST['Part'] . "'";
 		if ($result)
 		{
@@ -18,7 +19,7 @@
 		//Marking a option deleted, not actually deleting for data integrety
 		if (phpCAS::isAuthenticated() AND isset($_REQUEST['Kill']))
 		{
-			$result = mysql_query("UPDATE `QuickLogs`.`Types` SET `disabled` ='2' WHERE `index`='" . $_REQUEST['Kill'] . "'");
+			$result = mysqli_query($mysqli, "UPDATE `QuickLogs`.`Types` SET `disabled` ='2' WHERE `index`='" . $_REQUEST['Kill'] . "'");
 			if ($result)
 			{
 				//echo "Edited";
@@ -27,7 +28,7 @@
 		}else{
 			if (phpCAS::isAuthenticated() AND isset($_REQUEST['New_term'])){
 				//add a option to the list
-				$result = mysql_query("INSERT INTO `QuickLogs`.`Types` (`index`, `problem`, `disabled`) VALUES (NULL, '" . $_REQUEST['New_term'] . "', '0');");
+				$result = mysqli_query($mysqli, "INSERT INTO `QuickLogs`.`Types` (`index`, `problem`, `disabled`) VALUES (NULL, '" . $_REQUEST['New_term'] . "', '0');");
 				if ($result)
 				{
 					//echo "Edited";
@@ -38,6 +39,6 @@
 			}
 		}
 	}
-	
-	QuickLogs::db_disconnect();
+
+	QuickLogs::db_disconnect($mysqli);
 ?>

--- a/lite/chart.php
+++ b/lite/chart.php
@@ -1,6 +1,8 @@
 <?php
 	// Dan Berkowitz, berkod2@rpi.edu, dansberkowitz@gmail.com, Feb 2012
+	// Updated from PHP 5 to PHP 7, Joshua Rosenfeld, rosenj5@rpi.edu, jomaxro@gmail.com, Jan 2017
 	include '../core.php';
+	 $mysqli = mysqli_connect("localhost", "root", "bacon", "QuickLogs") or die("Could Not Connect To MYSQL or DATABASE");
 	if (!isset($_REQUEST['chart']))
 	{
 		echo "Invalid Post";
@@ -15,31 +17,31 @@
 			
 			$users = array ();
 			$problems = array();
-			$new_result = mysql_query("SELECT `ID`,`username` FROM `Users`;");
+			$new_result = mysqli_query($mysqli, "SELECT `ID`,`username` FROM `Users`;");
 			if ($new_result)
 			{
-				while ($row = mysql_fetch_array($new_result))
+				while ($row = mysqli_fetch_array($new_result))
 				{
 					$users[$row['ID']] = $row['username'];
 				}
 			}
-			$new_result = mysql_query("SELECT `index`,`problem` FROM `Types`;");
+			$new_result = mysqli_query($mysqli, "SELECT `index`,`problem` FROM `Types`;");
 			if ($new_result)
 			{
-				while ($row = mysql_fetch_array($new_result))
+				while ($row = mysqli_fetch_array($new_result))
 				{
 					$problems[$row['index']] = $row['problem'];
 				}
 			}
-			$new_result = mysql_query("SELECT * FROM `Logs` WHERE `timestamp`>((SELECT UNIX_TIMESTAMP(CURRENT_TIMESTAMP)) - (6 * 30 * 24 * 60 * 60));");
+			$new_result = mysqli_query($mysqli, "SELECT * FROM `Logs` WHERE `timestamp`>((SELECT UNIX_TIMESTAMP(CURRENT_TIMESTAMP)) - (6 * 30 * 24 * 60 * 60));");
 			if ($new_result)
 			{
-				while ($row = mysql_fetch_array($new_result))
+				while ($row = mysqli_fetch_array($new_result))
 				{
 					echo $row['timestamp'] . "," . $problems[$row['type']] . "," . $users[$row['userid']] . "\n";
 				}
 			}
-
+	
 			break;
 			
 		case "excel_12months":
@@ -50,31 +52,31 @@
 			
 			$users = array ();
 			$problems = array();
-			$new_result = mysql_query("SELECT `ID`,`username` FROM `Users`;");
+			$new_result = mysqli_query($mysqli, "SELECT `ID`,`username` FROM `Users`;");
 			if ($new_result)
 			{
-				while ($row = mysql_fetch_array($new_result))
+				while ($row = mysqli_fetch_array($new_result))
 				{
 					$users[$row['ID']] = $row['username'];
 				}
 			}
-			$new_result = mysql_query("SELECT `index`,`problem` FROM `Types`;");
+			$new_result = mysqli_query($mysqli, "SELECT `index`,`problem` FROM `Types`;");
 			if ($new_result)
 			{
-				while ($row = mysql_fetch_array($new_result))
+				while ($row = mysqli_fetch_array($new_result))
 				{
 					$problems[$row['index']] = $row['problem'];
 				}
 			}
-			$new_result = mysql_query("SELECT * FROM `Logs` WHERE `timestamp`>((SELECT UNIX_TIMESTAMP(CURRENT_TIMESTAMP)) - (12 * 30 * 24 * 60 * 60));");
+			$new_result = mysqli_query($mysqli, "SELECT * FROM `Logs` WHERE `timestamp`>((SELECT UNIX_TIMESTAMP(CURRENT_TIMESTAMP)) - (12 * 30 * 24 * 60 * 60));");
 			if ($new_result)
 			{
-				while ($row = mysql_fetch_array($new_result))
+				while ($row = mysqli_fetch_array($new_result))
 				{
 					echo $row['timestamp'] . "," . $problems[$row['type']] . "," . $users[$row['userid']] . "\n";
 				}
 			}
-
+	
 			break;
 			
 		case "excel_all":
@@ -85,26 +87,26 @@
 			
 			$users = array ();
 			$problems = array();
-			$new_result = mysql_query("SELECT `ID`,`username` FROM `Users`;");
+			$new_result = mysqli_query($mysqli, "SELECT `ID`,`username` FROM `Users`;");
 			if ($new_result)
 			{
-				while ($row = mysql_fetch_array($new_result))
+				while ($row = mysqli_fetch_array($new_result))
 				{
 					$users[$row['ID']] = $row['username'];
 				}
 			}
-			$new_result = mysql_query("SELECT `index`,`problem` FROM `Types`;");
+			$new_result = mysqli_query($mysqli, "SELECT `index`,`problem` FROM `Types`;");
 			if ($new_result)
 			{
-				while ($row = mysql_fetch_array($new_result))
+				while ($row = mysqli_fetch_array($new_result))
 				{
 					$problems[$row['index']] = $row['problem'];
 				}
 			}
-			$new_result = mysql_query("SELECT * FROM `Logs`;");
+			$new_result = mysqli_query($mysqli, "SELECT * FROM `Logs`;");
 			if ($new_result)
 			{
-				while ($row = mysql_fetch_array($new_result))
+				while ($row = mysqli_fetch_array($new_result))
 				{
 					echo $row['timestamp'] . "," . $problems[$row['type']] . "," . $users[$row['userid']] . "\n";
 				}
@@ -114,7 +116,7 @@
 			$returning_Data = array();
 			if (isset($_REQUEST['startTime']) && isset($_REQUEST['endTime']))
 			{
-				$new_result = mysql_query("SELECT DISTINCT `type` AS Type_ID FROM `Logs` WHERE `timestamp`>(" . mysql_real_escape_string($_REQUEST['startTime']) . ") AND `timestamp`<(" . mysql_real_escape_string($_REQUEST['endTime']) . ");");
+				$new_result = mysqli_query($mysqli, "SELECT DISTINCT `type` AS Type_ID FROM `Logs` WHERE `timestamp`>(" . mysqli_real_escape_string($mysqli, $_REQUEST['startTime']) . ") AND `timestamp`<(" . mysqli_real_escape_string($mysqli, $_REQUEST['endTime']) . ");");
 				//echo "SELECT DISTINCT `type` AS Type_ID FROM `Logs` WHERE `timestamp`>(" . mysql_real_escape_string($_REQUEST['startTime']) . ") AND `timestamp`<(" . mysql_real_escape_string($_REQUEST['endTime']) . ");";
 				if ($new_result)
 				{
@@ -122,16 +124,16 @@
 					{
 						array_push($returning_Data, $_REQUEST['id']);
 					}
-					while ($row = mysql_fetch_array($new_result))
+					while ($row = mysqli_fetch_array($new_result))
 					{
-						$result = mysql_query("SELECT COUNT(*) AS RecordNumber FROM `Logs` WHERE `type`='" . $row['Type_ID'] . "' AND `timestamp`>(" . mysql_real_escape_string($_REQUEST['startTime']) . ") AND `timestamp`<(" . mysql_real_escape_string($_REQUEST['endTime']) . ");");
+						$result = mysqli_query($mysqli, "SELECT COUNT(*) AS RecordNumber FROM `Logs` WHERE `type`='" . $row['Type_ID'] . "' AND `timestamp`>(" . mysqli_real_escape_string($mysqli, $_REQUEST['startTime']) . ") AND `timestamp`<(" . mysqli_real_escape_string($mysqli, $_REQUEST['endTime']) . ");");
 						if ($result)
 						{
-							$rowz = mysql_fetch_array($result);	
-							$name = mysql_query("SELECT `problem` FROM `Types` WHERE `index`='" . $row['Type_ID'] . "'");
+							$rowz = mysqli_fetch_array($result);	
+							$name = mysqli_query($mysqli, "SELECT `problem` FROM `Types` WHERE `index`='" . $row['Type_ID'] . "'");
 							if ($name)
 							{
-								$rowy = mysql_fetch_array($name);
+								$rowy = mysqli_fetch_array($name);
 								$tempArray = array();
 								array_push($tempArray, $rowy['problem']);
 								
@@ -192,19 +194,19 @@
 			if (isset($_REQUEST['startTime']) && isset($_REQUEST['endTime']))
 			{
 				$returned_result = array();
-				$new_result = mysql_query("SELECT DISTINCT `userid` AS User_ID FROM `Logs` WHERE `timestamp`>(" . mysql_real_escape_string($_REQUEST['startTime']) . ") AND `timestamp`<(" . mysql_real_escape_string($_REQUEST['endTime']) . ");");
+				$new_result = mysqli_query($mysqli, "SELECT DISTINCT `userid` AS User_ID FROM `Logs` WHERE `timestamp`>(" . mysqli_real_escape_string($mysqli, $_REQUEST['startTime']) . ") AND `timestamp`<(" . mysqli_real_escape_string($mysqli, $_REQUEST['endTime']) . ");");
 				if ($new_result)
 				{
-					while ($row = mysql_fetch_array($new_result))
+					while ($row = mysqli_fetch_array($new_result))
 					{
-						$result = mysql_query("SELECT COUNT(*) AS RecordNumber FROM `Logs` WHERE `userid`='" . $row['User_ID'] . "' AND `timestamp`>(" . mysql_real_escape_string($_REQUEST['startTime']) . ") AND `timestamp`<(" . mysql_real_escape_string($_REQUEST['endTime']) . ");");
+						$result = mysqli_query($mysqli, "SELECT COUNT(*) AS RecordNumber FROM `Logs` WHERE `userid`='" . $row['User_ID'] . "' AND `timestamp`>(" . mysqli_real_escape_string($mysqli, $_REQUEST['startTime']) . ") AND `timestamp`<(" . mysqli_real_escape_string($mysqli, $_REQUEST['endTime']) . ");");
 						if ($result)
 						{
-							$rowz = mysql_fetch_array($result);
-							$name = mysql_query("SELECT `username` FROM `Users` WHERE `ID`='" . $row['User_ID'] . "';");
+							$rowz = mysqli_fetch_array($result);
+							$name = mysqli_query($mysqli, "SELECT `username` FROM `Users` WHERE `ID`='" . $row['User_ID'] . "';");
 							if ($name)
 							{
-								$rowy = mysql_fetch_array($name);
+								$rowy = mysqli_fetch_array($name);
 								$thisRow = array();
 								array_push($thisRow, $rowy['username']);
 								array_push($thisRow, intval($rowz['RecordNumber']));
@@ -252,6 +254,6 @@
 				
 			break;
 	}
-
-	QuickLogs::db_disconnect();
-?>
+	
+	QuickLogs::db_disconnect($mysqli);
+	?>

--- a/lite/footer.php
+++ b/lite/footer.php
@@ -1,16 +1,16 @@
-<div id="Stats">					
-    <?PHP 
-            if (phpCAS::isAuthenticated())
-            {
-                    echo "<a href='./logout.php' class='labels'>Logout " . phpCAS::getUser() . "</a>";
-            }else
-            {
-                    echo "<a href='./login.php' class='labels'>Login</a>";
-            }
-    ?>	
+<div id="Stats">                    
+	<?PHP 
+		if (phpCAS::isAuthenticated())
+		{
+				echo "<a href='./logout.php' class='labels'>Logout " . phpCAS::getUser() . "</a>";
+		}else
+		{
+				echo "<a href='./login.php' class='labels'>Login</a>";
+		}
+		?>  
 </div>
 <div id="version">v<?PHP echo QuickLogs::get_version(); ?> <a href="https://github.com/daberkow/QuickLogs">Source</a></a></div>
 <div id="switch_ver">
-        <a href="http://j2ee7.server.rpi.edu:8080/helpdesk/stylesheets/welcome.faces" class="labels"> Send in a Ticket </a>
-        <p style="margin: 0;"><a href="./stats.php" class="labels">See Stats</a></p>
+	<a href="http://leet.arc.rpi.edu/forum" class="labels"> Send in a Ticket </a>
+	<p style="margin: 0;"><a href="./stats.php" class="labels">See Stats</a></p>
 </div>

--- a/lite/index.php
+++ b/lite/index.php
@@ -1,92 +1,111 @@
 <?PHP
 	// Dan Berkowitz, berkod2@rpi.edu, dansberkowitz@gmail.com, Feb 2012
-	/// This will go and fetch the default display, that relies on the `display` table index 0 being set with boxes
-	function get_default()
+	// Updated from PHP 5 to PHP 7, Joshua Rosenfeld, rosenj5@rpi.edu, jomaxro@gmail.com, Jan 2017
+	// This will go and fetch the default display, that relies on the `display` table index 0 being set with boxes
+	
+		include '../core.php';
+	
+	if(phpCAS::isAuthenticated())
+	{	}
+	else
 	{
-		$Customize = false;		//Dont allow customization
-		$result = mysql_query("SELECT * FROM `display` WHERE `user`='0' LIMIT 1");	
+		Header("Location: ./login.php");
+	}
+	 $mysqli = mysqli_connect("localhost", "root", "bacon", "QuickLogs") or die("Could Not Connect To MYSQL or DATABASE");
+	
+	function get_default($mysqli)
+	{
+		$Customize = false;     //Dont allow customization
+		$result = mysqli_query($mysqli, "SELECT * FROM `display` WHERE `user`='0' LIMIT 1");
 		if($result)
 		{
 			//successful
-			$row = mysql_fetch_array($result); //Should be run once
+			$row = mysqli_fetch_array($result); //Should be run once
 			
 			for($i = 1; $i < 11; $i++) //run through the boxes
 			{
 				$Button_Description[$i . "ID"] = $row['Box' . $i];
-				$why_bool = mysql_query("SELECT `problem` FROM `Types` WHERE `index`='" . $row['Box' . $i] . "' AND `disabled`=0 LIMIT 1");
-				$temp_holding = mysql_fetch_array($why_bool);
+				$why_bool = mysqli_query($mysqli, "SELECT `problem` FROM `Types` WHERE `index`='" . $row['Box' . $i] . "' AND `disabled`=0 LIMIT 1");
+				$temp_holding = mysqli_fetch_array($why_bool);
 				$Button_Description[$i] = $temp_holding['problem'];
 			}
 			return $Button_Description;
 		}
 	}
-	
 	//We get to try to do custimization, Im not a english major
-	function get_customized()
+	function get_customized($mysqli)
 	{
 		if(phpCAS::isAuthenticated())
 		{
-			$result = mysql_query("SELECT * FROM `display` WHERE `user`=(SELECT `ID` FROM `Users` WHERE `username`='" . phpCAS::getUser() . "' LIMIT 1)");
+			$result = mysqli_query($mysqli, "SELECT * FROM `display` WHERE `user`=(SELECT `ID` FROM `Users` WHERE `username`='" . phpCAS::getUser() . "' LIMIT 1)");
 			if($result)
 			{
 				//successful
-				$row = mysql_fetch_array($result); //Should be run once
+				$row = mysqli_fetch_array($result); //Should be run once
 				for($i = 1; $i < 11; $i++)
 				{
 					$Button_Description[$i . "ID"] = $row['Box' . $i];
-					$why_bool = mysql_query("SELECT `problem` FROM `Types` WHERE `index`='" . $row['Box' . $i] . "' AND `disabled`=0 LIMIT 1");
-					$temp_holding = mysql_fetch_array($why_bool);
+					$why_bool = mysqli_query($mysqli, "SELECT `problem` FROM `Types` WHERE `index`='" . $row['Box' . $i] . "' AND `disabled`=0 LIMIT 1");
+					$temp_holding = mysqli_fetch_array($why_bool);
 					$Button_Description[$i] = $temp_holding['problem'];
 				}
 				return $Button_Description;
 			}
 		}else{
 			//if you arent logged in CAS then you get default
-			return get_default();
+		header("Location: ./login.php");
+			exit;
 		}
 	}
-	
-	include '../core.php';
-		
 	//Assume that they arent a admin, then if they have authenicated take a look
 	$admin=false;
 	if (phpCAS::isAuthenticated())
 	{
-		$result = mysql_query("SELECT `type` FROM `Users` WHERE `username`='" . phpCAS::getUser() . "' LIMIT 1");
+		$result = mysqli_query($mysqli, "SELECT `type` FROM `Users` WHERE `username`='" . phpCAS::getUser() . "' LIMIT 1");
 		if($result)
 		{
 			//successful
-			$row = mysql_fetch_array($result); //Should be run once
+			$row = mysqli_fetch_array($result); //Should be run once
 			if ($row['type'] == "1")
 				$admin=true;
 		}
 	}
 	
 	//See if they are allowed custome settings, if they are try to get them.
-	$settings = mysql_query("SELECT `Active` FROM `Settings` WHERE `setting`=1");
+	$settings = mysqli_query($mysqli, "SELECT `Active` FROM `Settings` WHERE `setting`=1");
 	$Button_Description = array();
 	if ($settings AND phpCAS::isAuthenticated())
 	{
-		$row = mysql_fetch_array($settings);
+		$row = mysqli_fetch_array($settings);
 		if ($row['Active'] == "1")//forces same options
 		{
-			$Button_Description = get_default();
+			$Button_Description = get_default($mysqli);
 			$Customize = false;
 		}else{
-			$Button_Description = get_customized();
+			$Button_Description = get_customized($mysqli);
 			$Customize = true;
 		}
 	}else{
-		$Button_Description = get_default();
+		$Button_Description = get_default($mysqli);
 		$Customize = false;
 	}
 	//Closing connections is always good
-	QuickLogs::db_disconnect();
+	QuickLogs::db_disconnect($mysqli);
 	
-?>
-
+	?>
 <html>
 	<head>
+		<nav id="bar">
+			<ul>
+				<li><a class="nav-link red" href="/quicklogs" target="_blank">Quicklogs</a></li>
+				<li><a class="nav-link red" href="/forum" target="_blank">Forum</a></li>
+				<li><a class="nav-link red" href="http://leet.arc.rpi.edu:8000" target="_blank">Print Queue</a></li>
+				<li><a class="nav-link red" href="/printers" target="_blank">Printer Picker</a></li>
+				<li><a class="nav-link red" href="http://afsws.rpi.edu/AFS/dept/acs/consult/Schedule.html" target="_blank">Schedule</a></li>
+				<li><a class="nav-link red" href="https://apex.cct.rpi.edu/apex/f?p=187:SEARCH:34401092285::NO:::" target="_blank">Pickup</a></li>
+				<li><a class="nav-link red" href="http://hd-time.arc.rpi.edu/timecard.php?group=Helpdesk" target="_blank">Time Card</a></li>
+			</ul>
+		</nav>
 		<title class = "title">QuickLogs</title>
 		<link rel="stylesheet" type="text/css" href="./style.css"/>
 		<link href="http://www.rpi.edu/favicon.ico" type="image/ico" rel="icon">
@@ -96,24 +115,19 @@
 			//Clock and new clock were added cause touch screen kept double posting
 			var clock = 0;
 			function submit_options(passed_index) {
-				var new_clock = ((new Date().getTime()));
-				if ((clock+500)<=new_clock)
-				{
-					$.ajax({
-						type: 'POST',
-						url: "./submit.php",
-						data: {Task_ID: passed_index},
-						success: function(data) {
-							$("#result").html(data);
-							alert_user();
-						},
-						error: function(data) {
-							$("#result").html("ERROR");
-							$("#result").css("background", "red");
-						}
-					});
-					clock = (new Date().getTime());
-				}
+				$.ajax({
+					type: 'POST',
+					url: "./submit.php",
+					data: {Task_ID: passed_index},
+					success: function(data) {
+						$("#result").html(data);
+						alert_user();
+					},
+					error: function(data) {
+						$("#result").html("ERROR");
+						$("#result").css("background", "red");
+					}
+				});
 			}
 			
 			function alert_user()
@@ -122,7 +136,6 @@
 				var new_color = "#" + color;
 				$("#result").css("background", new_color);
 				recurse_alert(color);
-				
 			}
 			
 			function recurse_alert(old_colour)
@@ -132,12 +145,11 @@
 				while (new_color.length < 7)
 				{
 					new_color = "#0" + new_color.substr(1, new_color.length - 1);
-				} 
-				//$("#result").append("<p>old: " + the_color + " New: " + new_color + " " + parseInt("111111", 16).toString() + " </p>");
+				}
 				$("#result").css("background", new_color);
 				if( the_color<=15658734)
 				{
-					setTimeout(	"recurse_alert(" + the_color + ")", 50 );
+					setTimeout( "recurse_alert(" + the_color + ")", 50 );
 				}else{
 					$("#result").css("background", "white");
 				}
@@ -145,55 +157,120 @@
 		</script>
 	</head>
 	<body>
+		<!-- Make sure the page refreshes every 10 minutes -->
+		<script>var timedRefresh = setTimeout(function(){location.reload(true)},600000);</script>
 		<!-- DIVS! -->
 		<div id="main">
 			<div id="title">
 				<div class="logo"></div>
-				<a href="./index.php"><div id="logo">QuickLogs</div></a>
+				<a href="./index.php">
+					<div id="logo">QuickLogs</div>
+				</a>
 				<div id="result"></div>
 			</div>
 			<div class="red_bar"></div>
 			<div class="gray_bar"></div>
 			<!-- Here are all my rows, and the 8 buttons -->
 			<div id="row">
-				<a class="links" href="#"><div id="left" onclick='submit_options(<?PHP echo $Button_Description["1ID"]; ?>)'><div id='text'><p><?PHP echo $Button_Description[1]; ?></p></div></div></a>
-				<a class="links" href="#"><div id="right" onclick='submit_options(<?PHP echo $Button_Description["2ID"]; ?>)'><div id='text'><p><?PHP echo $Button_Description[2]; ?></p></div></div></a>
+				<a class="links" href="#">
+					<div id="left" onclick='submit_options(<?PHP echo $Button_Description["1ID"]; ?>)'>
+						<div id='text'>
+							<p><?PHP echo $Button_Description[1]; ?></p>
+						</div>
+					</div>
+				</a>
+				<a class="links" href="#">
+					<div id="right" onclick='submit_options(<?PHP echo $Button_Description["2ID"]; ?>)'>
+						<div id='text'>
+							<p><?PHP echo $Button_Description[2]; ?></p>
+						</div>
+					</div>
+				</a>
 			</div>
 			<div id="row">
-				<a class="links" href="#"><div id="left" onclick='submit_options(<?PHP echo $Button_Description["3ID"]; ?>)'><div id='text'><p><?PHP echo $Button_Description[3]; ?></p></div></div></a>
-				<a class="links" href="#"><div id="right" onclick='submit_options(<?PHP echo $Button_Description["4ID"]; ?>)'><div id='text'><p><?PHP echo $Button_Description[4]; ?></p></div></div></a>
+				<a class="links" href="#">
+					<div id="left" onclick='submit_options(<?PHP echo $Button_Description["3ID"]; ?>)'>
+						<div id='text'>
+							<p><?PHP echo $Button_Description[3]; ?></p>
+						</div>
+					</div>
+				</a>
+				<a class="links" href="#">
+					<div id="right" onclick='submit_options(<?PHP echo $Button_Description["4ID"]; ?>)'>
+						<div id='text'>
+							<p><?PHP echo $Button_Description[4]; ?></p>
+						</div>
+					</div>
+				</a>
 			</div>
 			<div id="row">
-				<a class="links" href="#"><div id="left" onclick='submit_options(<?PHP echo $Button_Description["5ID"]; ?>)'><div id='text'><p><?PHP echo $Button_Description[5]; ?></p></div></div></a>
-				<a class="links" href="#"><div id="right" onclick='submit_options(<?PHP echo $Button_Description["6ID"]; ?>)'><div id='text'><p><?PHP echo $Button_Description[6]; ?></p></div></div></a>
+				<a class="links" href="#">
+					<div id="left" onclick='submit_options(<?PHP echo $Button_Description["5ID"]; ?>)'>
+						<div id='text'>
+							<p><?PHP echo $Button_Description[5]; ?></p>
+						</div>
+					</div>
+				</a>
+				<a class="links" href="#">
+					<div id="right" onclick='submit_options(<?PHP echo $Button_Description["6ID"]; ?>)'>
+						<div id='text'>
+							<p><?PHP echo $Button_Description[6]; ?></p>
+						</div>
+					</div>
+				</a>
 			</div>
 			<div id="row">
-				<a class="links" href="#"><div id="left" onclick='submit_options(<?PHP echo $Button_Description["7ID"]; ?>)'><div id='text'><p><?PHP echo $Button_Description[7]; ?></p></div></div></a>
-				<a class="links" href="#"><div id="right" onclick='submit_options(<?PHP echo $Button_Description["8ID"]; ?>)'><div id='text'><p><?PHP echo $Button_Description[8]; ?></p></div></div></a>
+				<a class="links" href="#">
+					<div id="left" onclick='submit_options(<?PHP echo $Button_Description["7ID"]; ?>)'>
+						<div id='text'>
+							<p><?PHP echo $Button_Description[7]; ?></p>
+						</div>
+					</div>
+				</a>
+				<a class="links" href="#">
+					<div id="right" onclick='submit_options(<?PHP echo $Button_Description["8ID"]; ?>)'>
+						<div id='text'>
+							<p><?PHP echo $Button_Description[8]; ?></p>
+						</div>
+					</div>
+				</a>
 			</div>
 			<div id="row">
-				<a class="links" href="#"><div id="left" onclick='submit_options(<?PHP echo $Button_Description["9ID"]; ?>)'><div id='text'><p><?PHP echo $Button_Description[9]; ?></p></div></div></a>
-				<a class="links" href="#"><div id="right" onclick='submit_options(<?PHP echo $Button_Description["10ID"]; ?>)'><div id='text'><p><?PHP echo $Button_Description[10]; ?></p></div></div></a>
+				<a class="links" href="#">
+					<div id="left" onclick='submit_options(<?PHP echo $Button_Description["9ID"]; ?>)'>
+						<div id='text'>
+							<p><?PHP echo $Button_Description[9]; ?></p>
+						</div>
+					</div>
+				</a>
+				<a class="links" href="#">
+					<div id="right" onclick='submit_options(<?PHP echo $Button_Description["10ID"]; ?>)'>
+						<div id='text'>
+							<p><?PHP echo $Button_Description[10]; ?></p>
+						</div>
+					</div>
+				</a>
 			</div>
 			<!-- NEW SECTION! -->
 			<hr>
 			<div id="footer">
-				<div id="Stats">					
+				<div id="Stats">
 					<?PHP 
 						if (phpCAS::isAuthenticated())
 						{//Authenacted users get logout
-							echo "<a href='./logout.php' class='labels'>Logout " . phpCAS::getUser() . "</a>";
+							echo "<a href='./logout.php' class='labels'>Logout " . strtolower(phpCAS::getUser()) . "</a>";
 						}else
 						{
 							echo "<a href='./login.php' class='labels'>Login</a>";
 						}
 						//Admins or people who can customize get settings
 						if ($Customize || $admin) { echo "<p style='margin:0;'><a href='./settings.php' class='labels'>Settings</a></p>"; }
-					?>	
+						?>  
 				</div>
-				<div id="version">v<?PHP echo QuickLogs::get_version(); ?> <a href="https://github.com/daberkow/QuickLogs">Source</a></a></div> <!-- YAY -->
+				<div id="version">v<?PHP echo QuickLogs::get_version(); ?> <a href="https://github.com/daberkow/QuickLogs">Source</a></a></div>
+				<!-- YAY -->
 				<div id="switch_ver">
-					<a href="http://j2ee7.server.rpi.edu:8080/helpdesk/stylesheets/welcome.faces" class="labels"> Send in a Ticket </a>
+					<a href="http://leet.arc.rpi.edu/forum" class="labels"> Send in a Ticket </a>
 					<p style="margin: 0;"><a href="./stats.php" class="labels">See Stats</a></p>
 				</div>
 			</div>

--- a/lite/login.php
+++ b/lite/login.php
@@ -1,5 +1,6 @@
 <?PHP
 	// Dan Berkowitz, berkod2@rpi.edu, dansberkowitz@gmail.com, Feb 2012
+	// Updated from PHP 5 to PHP 7, Joshua Rosenfeld, rosenj5@rpi.edu, jomaxro@gmail.com, Jan 2017
 	include '../core.php';
 		
 	//If not authenticated then do it
@@ -8,19 +9,19 @@
 		phpCAS::forceAuthentication();
 	}else{
 		//We are authenticated, but we may not be in the users database		
-		QuickLogs::db_connect();
+		$mysqli = mysqli_connect("localhost", "root", "bacon", "QuickLogs") or die("Could Not Connect To MYSQL or DATABASE");
 		
-		$user_exists = mysql_query("SELECT * FROM `Users` WHERE `username`='" . phpCAS::getUser() ."'");
+		$user_exists = mysqli_query($mysqli, "SELECT * FROM `Users` WHERE `username`='" . phpCAS::getUser() ."'");
 		
-		if (mysql_num_rows($user_exists) == 0) // True is user is not in the database
+		if (mysqli_num_rows($user_exists) == 0) // True is user is not in the database
 		{
-			$sql = mysql_query("INSERT INTO `QuickLogs`.`Users` (`ID` ,`username` ,`type`) VALUES (NULL , '" . phpCAS::getUser() . "', '0');");
+			$sql = mysqli_query($mysqli, "INSERT INTO `QuickLogs`.`Users` (`ID` ,`username` ,`type`) VALUES (NULL , '" . phpCAS::getUser() . "', '0');");
 			if ($sql)
 			{ //Insert worked, copy default display data
-				mysql_query("INSERT INTO `display` (`user`,`Box1`,`Box2`,`Box3`,`Box4`,`Box5`,`Box6`,`Box7`,`Box8`,`Box9`,`Box10`) (SELECT (SELECT `ID` FROM `Users` WHERE `username`='" . phpCAS::getUser() ."' LIMIT 1), `display`.`Box1`, `display`.`Box2`, `display`.`Box3`, `display`.`Box4`, `display`.`Box5`, `display`.`Box6`, `display`.`Box7`, `display`.`Box8`, `display`.`Box9`, `display`.`Box10` FROM `display` WHERE `user`=0)");
+				mysqli_query($mysqli, "INSERT INTO `display` (`user`,`Box1`,`Box2`,`Box3`,`Box4`,`Box5`,`Box6`,`Box7`,`Box8`,`Box9`,`Box10`) (SELECT (SELECT `ID` FROM `Users` WHERE `username`='" . phpCAS::getUser() ."' LIMIT 1), `display`.`Box1`, `display`.`Box2`, `display`.`Box3`, `display`.`Box4`, `display`.`Box5`, `display`.`Box6`, `display`.`Box7`, `display`.`Box8`, `display`.`Box9`, `display`.`Box10` FROM `display` WHERE `user`=0)");
 			}
 		}
-		QuickLogs::db_disconnect();
+		QuickLogs::db_disconnect($mysqli);
 	}
 	header("location: ./index.php");
-?>
+	?>

--- a/lite/logout.php
+++ b/lite/logout.php
@@ -1,5 +1,6 @@
 <?PHP
 	// Dan Berkowitz, berkod2@rpi.edu, dansberkowitz@gmail.com, Feb 2012
+	// Updated from PHP 5 to PHP 7, Joshua Rosenfeld, rosenj5@rpi.edu, jomaxro@gmail.com, Jan 2017
 	include_once '../cas/CAS.php';
 	
 	phpCAS::client(CAS_VERSION_2_0,'cas-auth.rpi.edu',443,'/cas/');
@@ -13,7 +14,3 @@
 	}
 	header( 'Location: ./index.php' );
 ?>
-
-
-			
-			

--- a/lite/settings.php
+++ b/lite/settings.php
@@ -1,21 +1,22 @@
 <?PHP
 	// Dan Berkowitz, berkod2@rpi.edu, dansberkowitz@gmail.com, Feb 2012
+	// Updated from PHP 5 to PHP 7, Joshua Rosenfeld, rosenj5@rpi.edu, jomaxro@gmail.com, Jan 2017
 	include '../core.php';
 	
 	/// This will go and fetch the default display, that relies on the `display` table index 0 being set with boxes
-	function get_default()
+	function get_default($mysqli)
 	{
-		$result = mysql_query("SELECT * FROM `display` WHERE `user`='0' LIMIT 1");	
+		$result = mysqli_query($mysqli, "SELECT * FROM `display` WHERE `user`='0' LIMIT 1");	
 		if($result)
 		{
 			//successful
-			$row = mysql_fetch_array($result); //Should be run once
+			$row = mysqli_fetch_array($result); //Should be run once
 			
 			for($i = 1; $i < 11; $i++) //run through the boxes
 			{
 				$Button_Description[$i . "ID"] = $row['Box' . $i];
-				$why_bool = mysql_query("SELECT `problem` FROM `Types` WHERE `index`='" . $row['Box' . $i] . "' AND `disabled`=0 LIMIT 1");
-				$temp_holding = mysql_fetch_array($why_bool);
+				$why_bool = mysqli_query($mysqli, "SELECT `problem` FROM `Types` WHERE `index`='" . $row['Box' . $i] . "' AND `disabled`=0 LIMIT 1");
+				$temp_holding = mysqli_fetch_array($why_bool);
 				$Button_Description[$i] = $temp_holding['problem'];
 			}
 			return $Button_Description;
@@ -23,27 +24,27 @@
 	}
 	
 	//We get to try to do custimization, Im not a english major
-	function get_customized()
+	function get_customized($mysqli)
 	{
 		if(phpCAS::isAuthenticated())
 		{
-			$result = mysql_query("SELECT * FROM `display` WHERE `user`=(SELECT `ID` FROM `Users` WHERE `username`='" . phpCAS::getUser() . "' LIMIT 1)");
+			$result = mysqli_query($mysqli, "SELECT * FROM `display` WHERE `user`=(SELECT `ID` FROM `Users` WHERE `username`='" . phpCAS::getUser() . "' LIMIT 1)");
 			if($result)
 			{
 				//successful
-				$row = mysql_fetch_array($result); //Should be run once
+				$row = mysqli_fetch_array($result); //Should be run once
 				for($i = 1; $i < 11; $i++)
 				{
 					$Button_Description[$i . "ID"] = $row['Box' . $i];
-					$why_bool = mysql_query("SELECT `problem` FROM `Types` WHERE `index`='" . $row['Box' . $i] . "' AND `disabled`=0 LIMIT 1");
-					$temp_holding = mysql_fetch_array($why_bool);
+					$why_bool = mysqli_query($mysqli, "SELECT `problem` FROM `Types` WHERE `index`='" . $row['Box' . $i] . "' AND `disabled`=0 LIMIT 1");
+					$temp_holding = mysqli_fetch_array($why_bool);
 					$Button_Description[$i] = $temp_holding['problem'];
 				}
 				return $Button_Description;
 			}
 		}else{
 			//if you arent logged in CAS then you get default
-			return get_default();
+			return get_default($mysqli);
 		}
 	}
 	
@@ -51,43 +52,41 @@
 	$admin=false;
 	if (phpCAS::isAuthenticated())
 	{
-		$result = mysql_query("SELECT `type` FROM `Users` WHERE `username`='" . phpCAS::getUser() . "' LIMIT 1");
+		$result = mysqli_query($mysqli, "SELECT `type` FROM `Users` WHERE `username`='" . phpCAS::getUser() . "' LIMIT 1");
 		if($result)
 		{
 			//successful
-			$row = mysql_fetch_array($result); //Should be run once
+			$row = mysqli_fetch_array($result); //Should be run once
 			if ($row['type'] == "1")
 			{
-				$def_OPTIONS = get_default();
+				$def_OPTIONS = get_default($mysqli);
 				$admin=true;
 			}
 		}
 	}
 	//See if they are allowed custome settings, if they are try to get them.
-	$settings = mysql_query("SELECT `Active` FROM `Settings` WHERE `setting`=1");
+	$settings = mysqli_query($mysqli, "SELECT `Active` FROM `Settings` WHERE `setting`=1");
 	$Button_Description = array();
 	if ($settings AND phpCAS::isAuthenticated())
 	{
-		$row = mysql_fetch_array($settings);
+		$row = mysqli_fetch_array($settings);
 		if ($row['Active'] == "1")//forces same options
 		{
-			$Button_Description = get_customized();
+			$Button_Description = get_customized($mysqli);
 			$Customize = false;
 		}else{
-			$Button_Description = get_customized();
+			$Button_Description = get_customized($mysqli);
 			$Customize = true;
 		}
 	}else{
-		$Button_Description = get_default();
+		$Button_Description = get_default($mysqli);
 		$Customize = false;
 	}
 	//Closing connections is always good
 	//Exept when page needs it again anyway
 	//QuickLogs::db_disconnect();
-
-?>
-
-
+	
+	?>
 <html>
 	<head>
 		<title class = "title">QuickLogs</title>
@@ -131,392 +130,423 @@
 					});
 				
 			}
-			</script>
+		</script>
 	</head>
 	<body>
 		<div id="main">
 			<div id="title">
-				<a href="./index.php"><div id="logo">QuickLogs</div></a>
+				<a href="./index.php">
+					<div id="logo">QuickLogs</div>
+				</a>
 				<div id="result"></div>
 			</div>
 			<form action="./submit.php" method="post">
-			<?PHP 
-				if (!$Customize)
-					echo "Custom Loaded but not in use";
-					
-				//removed mysql disconenct and reconnect	
-					
-				$result = mysql_query("SELECT `index`,`problem` FROM `Types` WHERE `disabled`=0 LIMIT 0, 100"); //limit just in case
-				//error_reporting(E_ALL);
-				$OPTIONS = array();
-				$OPTIONS_ID = array();
-				if($result)
-				{
-					while ($row = mysql_fetch_array($result))
+				<?PHP 
+					if (!$Customize)
+						echo "Custom Loaded but not in use";
+						
+					//removed mysql disconenct and reconnect	
+						
+					$result = mysql_query("SELECT `index`,`problem` FROM `Types` WHERE `disabled`=0 LIMIT 0, 100"); //limit just in case
+					//error_reporting(E_ALL);
+					$OPTIONS = array();
+					$OPTIONS_ID = array();
+					if($result)
 					{
-						//echo $row['problem'] . $row['index'];
-						array_push($OPTIONS, $row['problem']);
-						array_push($OPTIONS_ID, $row['index']);
-						//echo $OPTIONS[count($OPTIONS)];
+						while ($row = mysql_fetch_array($result))
+						{
+							//echo $row['problem'] . $row['index'];
+							array_push($OPTIONS, $row['problem']);
+							array_push($OPTIONS_ID, $row['index']);
+							//echo $OPTIONS[count($OPTIONS)];
+						}
 					}
-				}
-			?>
+					?>
 				<h3>My Options</h3>
 				<div id="row">
-					<a class="links"><div id="left" ><select name='Box1' id='Box1'>
-						<?PHP 
-						for($i = 0; $i < count($OPTIONS); $i++)
-						{
-							if ($Button_Description["1ID"] == $OPTIONS_ID[$i])
-							{
-								echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
-							}else{
-								echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
-							}
-						}
-						?></select></div></a>
-					<a class="links"><div id="right" ><select name='Box2' id='Box2'>
-						<?PHP 
-						for($i = 0; $i < count($OPTIONS); $i++)
-						{
-							if ($Button_Description["2ID"] == $OPTIONS_ID[$i])
-							{
-								echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
-							}else{
-								echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
-							}
-						}
-						?></select></div></a>
+					<a class="links">
+						<div id="left" ><select name='Box1' id='Box1'>
+							<?PHP 
+								for($i = 0; $i < count($OPTIONS); $i++)
+								{
+									if ($Button_Description["1ID"] == $OPTIONS_ID[$i])
+									{
+										echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
+									}else{
+										echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
+									}
+								}
+								?></select>
+						</div>
+					</a>
+					<a class="links">
+						<div id="right" ><select name='Box2' id='Box2'>
+							<?PHP 
+								for($i = 0; $i < count($OPTIONS); $i++)
+								{
+									if ($Button_Description["2ID"] == $OPTIONS_ID[$i])
+									{
+										echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
+									}else{
+										echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
+									}
+								}
+								?></select>
+						</div>
+					</a>
 				</div>
 				<div id="row">
-					<a class="links"><div id="left" ><select name='Box3' id='Box3'>
-						<?PHP 
-						for($i = 0; $i < count($OPTIONS); $i++)
-						{
-							if ($Button_Description["3ID"] == $OPTIONS_ID[$i])
-							{
-								echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
-							}else{
-								echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
-							}
-						}
-						?></select></div></a>
-					<a class="links"><div id="right" ><select name='Box4' id='Box4'>
-						<?PHP 
-						for($i = 0; $i < count($OPTIONS); $i++)
-						{
-							if ($Button_Description["4ID"] == $OPTIONS_ID[$i])
-							{
-								echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
-							}else{
-								echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
-							}
-						}
-						?></select></div></a>
+					<a class="links">
+						<div id="left" ><select name='Box3' id='Box3'>
+							<?PHP 
+								for($i = 0; $i < count($OPTIONS); $i++)
+								{
+									if ($Button_Description["3ID"] == $OPTIONS_ID[$i])
+									{
+										echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
+									}else{
+										echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
+									}
+								}
+								?></select>
+						</div>
+					</a>
+					<a class="links">
+						<div id="right" ><select name='Box4' id='Box4'>
+							<?PHP 
+								for($i = 0; $i < count($OPTIONS); $i++)
+								{
+									if ($Button_Description["4ID"] == $OPTIONS_ID[$i])
+									{
+										echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
+									}else{
+										echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
+									}
+								}
+								?></select>
+						</div>
+					</a>
 				</div>
 				<div id="row">
-					<a class="links"><div id="left" ><select name='Box5' id='Box5'>
-						<?PHP 
-						for($i = 0; $i < count($OPTIONS); $i++)
-						{
-							if ($Button_Description["5ID"] == $OPTIONS_ID[$i])
-							{
-								echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
-							}else{
-								echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
-							}
-						}
-						?></select></div></a>
-					<a class="links"><div id="right" ><select name='Box6' id='Box6'>
-						<?PHP 
-						for($i = 0; $i < count($OPTIONS); $i++)
-						{
-							if ($Button_Description["6ID"] == $OPTIONS_ID[$i])
-							{
-								echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
-							}else{
-								echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
-							}
-						}
-						?></select></div></a>
+					<a class="links">
+						<div id="left" ><select name='Box5' id='Box5'>
+							<?PHP 
+								for($i = 0; $i < count($OPTIONS); $i++)
+								{
+									if ($Button_Description["5ID"] == $OPTIONS_ID[$i])
+									{
+										echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
+									}else{
+										echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
+									}
+								}
+								?></select>
+						</div>
+					</a>
+					<a class="links">
+						<div id="right" ><select name='Box6' id='Box6'>
+							<?PHP 
+								for($i = 0; $i < count($OPTIONS); $i++)
+								{
+									if ($Button_Description["6ID"] == $OPTIONS_ID[$i])
+									{
+										echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
+									}else{
+										echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
+									}
+								}
+								?></select>
+						</div>
+					</a>
 				</div>
 				<div id="row">
-					<a class="links"><div id="left" ><select name='Box7' id='Box7'>
-						<?PHP 
-						for($i = 0; $i < count($OPTIONS); $i++)
-						{
-							if ($Button_Description["7ID"] == $OPTIONS_ID[$i])
-							{
-								echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
-							}else{
-								echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
-							}
-						}
-						?></select></div></a>
-					<a class="links"><div id="right" ><select name='Box8' id='Box8'>
-						<?PHP 
-						for($i = 0; $i < count($OPTIONS); $i++)
-						{
-							if ($Button_Description["8ID"] == $OPTIONS_ID[$i])
-							{
-								echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
-							}else{
-								echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
-							}
-						}
-						?></select></div></a>
+					<a class="links">
+						<div id="left" ><select name='Box7' id='Box7'>
+							<?PHP 
+								for($i = 0; $i < count($OPTIONS); $i++)
+								{
+									if ($Button_Description["7ID"] == $OPTIONS_ID[$i])
+									{
+										echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
+									}else{
+										echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
+									}
+								}
+								?></select>
+						</div>
+					</a>
+					<a class="links">
+						<div id="right" ><select name='Box8' id='Box8'>
+							<?PHP 
+								for($i = 0; $i < count($OPTIONS); $i++)
+								{
+									if ($Button_Description["8ID"] == $OPTIONS_ID[$i])
+									{
+										echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
+									}else{
+										echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
+									}
+								}
+								?></select>
+						</div>
+					</a>
 				</div>
 				<div id="row">
-					<a class="links"><div id="left" ><select name='Box9' id='Box9'>
-						<?PHP 
-						for($i = 0; $i < count($OPTIONS); $i++)
-						{
-							if ($Button_Description["9ID"] == $OPTIONS_ID[$i])
-							{
-								echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
-							}else{
-								echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
-							}
-						}
-						?></select></div></a>
-					<a class="links"><div id="right" ><select name='Box10' id='Box10'>
-						<?PHP 
-						for($i = 0; $i < count($OPTIONS); $i++)
-						{
-							if ($Button_Description["10ID"] == $OPTIONS_ID[$i])
-							{
-								echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
-							}else{
-								echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
-							}
-						}
-						?></select></div></a>
+					<a class="links">
+						<div id="left" ><select name='Box9' id='Box9'>
+							<?PHP 
+								for($i = 0; $i < count($OPTIONS); $i++)
+								{
+									if ($Button_Description["9ID"] == $OPTIONS_ID[$i])
+									{
+										echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
+									}else{
+										echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
+									}
+								}
+								?></select>
+						</div>
+					</a>
+					<a class="links">
+						<div id="right" ><select name='Box10' id='Box10'>
+							<?PHP 
+								for($i = 0; $i < count($OPTIONS); $i++)
+								{
+									if ($Button_Description["10ID"] == $OPTIONS_ID[$i])
+									{
+										echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
+									}else{
+										echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
+									}
+								}
+								?></select>
+						</div>
+					</a>
 				</div>
 				<div id="buttonz">
 					<input TYPE="submit" id="cmdSubmit" VALUE="Update Settings"/>
 				</div>
 			</form>
 			<?PHP
-			
-			if ($admin)
-			{
-				echo "<hr>
-						<h3>All Users Default</h3>
-						<form action='./submit.php' method='post'>
-							<input type='hidden' name='Admin' id='Admin' value='Admin'>
-							<input type='checkbox' id='Customize_On' name='Customize_On' value='Customize_On' "; if ($Customize) {echo "checked";} 
-				echo		"/> Allow Users to Customize Their Options
-							<div id='row'>
-								<a class='links'><div id='left' ><select name='Box1' id='Box1'>";
-									
-									for($i = 0; $i < count($OPTIONS); $i++)
-									{
-										if ($def_OPTIONS["1ID"] == $OPTIONS_ID[$i])
+				if ($admin)
+				{
+					echo "<hr>
+							<h3>All Users Default</h3>
+							<form action='./submit.php' method='post'>
+								<input type='hidden' name='Admin' id='Admin' value='Admin'>
+								<input type='checkbox' id='Customize_On' name='Customize_On' value='Customize_On' "; if ($Customize) {echo "checked";} 
+					echo		"/> Allow Users to Customize Their Options
+								<div id='row'>
+									<a class='links'><div id='left' ><select name='Box1' id='Box1'>";
+										
+										for($i = 0; $i < count($OPTIONS); $i++)
 										{
-											echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
-										}else{
-											echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
+											if ($def_OPTIONS["1ID"] == $OPTIONS_ID[$i])
+											{
+												echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
+											}else{
+												echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
+											}
 										}
-									}
-				echo				"</select></div></a>
-								<a class='links'><div id='right'><select name='Box2' id='Box2'>";
-									
-									for($i = 0; $i < count($OPTIONS); $i++)
-									{
-										if ($def_OPTIONS["2ID"] == $OPTIONS_ID[$i])
+					echo				"</select></div></a>
+									<a class='links'><div id='right'><select name='Box2' id='Box2'>";
+										
+										for($i = 0; $i < count($OPTIONS); $i++)
 										{
-											echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
-										}else{
-											echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
+											if ($def_OPTIONS["2ID"] == $OPTIONS_ID[$i])
+											{
+												echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
+											}else{
+												echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
+											}
 										}
-									}
-				echo				"</select></div></a>
-							</div>
-							<div id='row'>
-								<a class='links'><div id='left'><select name='Box3' id='Box3'>";
+					echo				"</select></div></a>
+								</div>
+								<div id='row'>
+									<a class='links'><div id='left'><select name='Box3' id='Box3'>";
+					
+										for($i = 0; $i < count($OPTIONS); $i++)
+										{
+											if ($def_OPTIONS["3ID"] == $OPTIONS_ID[$i])
+											{
+												echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
+											}else{
+												echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
+											}
+										}
+					echo				"</select></div></a>
+									<a class='links'><div id='right' ><select name='Box4' id='Box4'>";
+										 
+										for($i = 0; $i < count($OPTIONS); $i++)
+										{
+											if ($def_OPTIONS["4ID"] == $OPTIONS_ID[$i])
+											{
+												echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
+											}else{
+												echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
+											}
+										}
+					echo					"</select></div></a>
+								</div>
+								<div id='row'>
+									<a class='links'><div id='left' ><select name='Box5' id='Box5'>";
+										 
+										for($i = 0; $i < count($OPTIONS); $i++)
+										{
+											if ($def_OPTIONS["5ID"] == $OPTIONS_ID[$i])
+											{
+												echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
+											}else{
+												echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
+											}
+										}
+					echo				"</select></div></a>
+									<a class='links'><div id='right' ><select name='Box6' id='Box6'>";
+										 
+										for($i = 0; $i < count($OPTIONS); $i++)
+										{
+											if ($def_OPTIONS["6ID"] == $OPTIONS_ID[$i])
+											{
+												echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
+											}else{
+												echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
+											}
+										}
+					echo					"</select></div></a>
+								</div>
+								<div id='row'>
+									<a class='links'><div id='left' ><select name='Box7' id='Box7'>";
 				
-									for($i = 0; $i < count($OPTIONS); $i++)
-									{
-										if ($def_OPTIONS["3ID"] == $OPTIONS_ID[$i])
+										for($i = 0; $i < count($OPTIONS); $i++)
 										{
-											echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
-										}else{
-											echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
+											if ($def_OPTIONS["7ID"] == $OPTIONS_ID[$i])
+											{
+												echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
+											}else{
+												echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
+											}
 										}
-									}
-				echo				"</select></div></a>
-								<a class='links'><div id='right' ><select name='Box4' id='Box4'>";
-									 
-									for($i = 0; $i < count($OPTIONS); $i++)
-									{
-										if ($def_OPTIONS["4ID"] == $OPTIONS_ID[$i])
+					echo				"</select></div></a>
+									<a class='links'><div id='right' ><select name='Box8' id='Box8'>";
+										
+										for($i = 0; $i < count($OPTIONS); $i++)
 										{
-											echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
-										}else{
-											echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
+											if ($def_OPTIONS["8ID"] == $OPTIONS_ID[$i])
+											{
+												echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
+											}else{
+												echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
+											}
 										}
-									}
-				echo					"</select></div></a>
-							</div>
-							<div id='row'>
-								<a class='links'><div id='left' ><select name='Box5' id='Box5'>";
-									 
-									for($i = 0; $i < count($OPTIONS); $i++)
-									{
-										if ($def_OPTIONS["5ID"] == $OPTIONS_ID[$i])
+					echo				"</select></div></a>
+								</div>
+								<div id='row'>
+									<a class='links'><div id='left' ><select name='Box9' id='Box9'>";
+								
+								for($i = 0; $i < count($OPTIONS); $i++)
 										{
-											echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
-										}else{
-											echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
+											if ($def_OPTIONS["9ID"] == $OPTIONS_ID[$i])
+											{
+												echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
+											}else{
+												echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
+											}
 										}
-									}
-				echo				"</select></div></a>
-								<a class='links'><div id='right' ><select name='Box6' id='Box6'>";
-									 
-									for($i = 0; $i < count($OPTIONS); $i++)
-									{
-										if ($def_OPTIONS["6ID"] == $OPTIONS_ID[$i])
+					echo				"</select></div></a>
+									<a class='links'><div id='right' ><select name='Box10' id='Box10'>";
+										
+										for($i = 0; $i < count($OPTIONS); $i++)
 										{
-											echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
-										}else{
-											echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
+											if ($def_OPTIONS["10ID"] == $OPTIONS_ID[$i])
+											{
+												echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
+											}else{
+												echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
+											}
 										}
-									}
-				echo					"</select></div></a>
-							</div>
-							<div id='row'>
-								<a class='links'><div id='left' ><select name='Box7' id='Box7'>";
-
-									for($i = 0; $i < count($OPTIONS); $i++)
-									{
-										if ($def_OPTIONS["7ID"] == $OPTIONS_ID[$i])
-										{
-											echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
-										}else{
-											echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
-										}
-									}
-				echo				"</select></div></a>
-								<a class='links'><div id='right' ><select name='Box8' id='Box8'>";
-									
-									for($i = 0; $i < count($OPTIONS); $i++)
-									{
-										if ($def_OPTIONS["8ID"] == $OPTIONS_ID[$i])
-										{
-											echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
-										}else{
-											echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
-										}
-									}
-				echo				"</select></div></a>
-							</div>
-							<div id='row'>
-								<a class='links'><div id='left' ><select name='Box9' id='Box9'>";
-							
-							for($i = 0; $i < count($OPTIONS); $i++)
-									{
-										if ($def_OPTIONS["9ID"] == $OPTIONS_ID[$i])
-										{
-											echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
-										}else{
-											echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
-										}
-									}
-				echo				"</select></div></a>
-								<a class='links'><div id='right' ><select name='Box10' id='Box10'>";
-									
-									for($i = 0; $i < count($OPTIONS); $i++)
-									{
-										if ($def_OPTIONS["10ID"] == $OPTIONS_ID[$i])
-										{
-											echo "<option value=" . $OPTIONS_ID[$i] . " selected='selected'>" . $OPTIONS[$i] . "</option>";
-										}else{
-											echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
-										}
-									}
-				echo				"</select></div></a>
-							</div>
-							
-							<div id='buttonz'>
-									<input TYPE='submit' id='cmdSubmit' VALUE='Update Settings'/>
-							</div>
-						</form>
-						<hr>
-						<p>Enabled Options(reload page to make selectable):</p>";
-
-						$result = mysql_query("SELECT `index`,`problem` FROM `Types` WHERE `disabled`<'2' LIMIT 0, 100"); //limit just in case
-						//error_reporting(E_ALL);
-						$OPTIONS = array();
-						$OPTIONS_ID = array();
-						if($result)
-						{
-							while ($row = mysql_fetch_array($result))
-							{
-								//echo $row['problem'] . $row['index'];
-								array_push($OPTIONS, $row['problem']);
-								array_push($OPTIONS_ID, $row['index']);
-								//echo $OPTIONS[count($OPTIONS)];
-							}
-						}
-						
-						for($i = 0; $i < count($OPTIONS); $i++)
-						{
-							//Trying to work on split, at this point for the few times this is used, a list is good
-							echo "<div id='selection_of_options" . 0 . "'>";
-							echo 	"<input type='checkbox' value=" . $OPTIONS_ID[$i] . " onclick='change_option(" . $OPTIONS_ID[$i];
-							
-							$result = mysql_query("SELECT `disabled` FROM `Types` WHERE `index`='" . $OPTIONS_ID[$i] . "'");
-							
+					echo				"</select></div></a>
+								</div>
+								
+								<div id='buttonz'>
+										<input TYPE='submit' id='cmdSubmit' VALUE='Update Settings'/>
+								</div>
+							</form>
+							<hr>
+							<p>Enabled Options(reload page to make selectable):</p>";
+				
+							$result = mysql_query("SELECT `index`,`problem` FROM `Types` WHERE `disabled`<'2' LIMIT 0, 100"); //limit just in case
+							//error_reporting(E_ALL);
+							$OPTIONS = array();
+							$OPTIONS_ID = array();
 							if($result)
 							{
-								$row = mysql_fetch_array($result);
-								if ($row['disabled'] == "0")
+								while ($row = mysql_fetch_array($result))
 								{
-									echo ",0)' checked";
-								}else{
-									echo ",1)' ";
+									//echo $row['problem'] . $row['index'];
+									array_push($OPTIONS, $row['problem']);
+									array_push($OPTIONS_ID, $row['index']);
+									//echo $OPTIONS[count($OPTIONS)];
 								}
-							}else{
-								echo ")' ";
 							}
 							
-							echo "/>" . $OPTIONS[$i] . "";
-							echo "</div>";
-						}
-						
-						
-						echo "<p>New Option:</p><form action='./change.php' method='post'>
-							<input class='input_box' type='text' name='New_term' id='New_term'/>
-						<input TYPE='submit' id='cmdSubmit' VALUE='New Option'/></form>";
-						
-						
-						echo "<p>Delete Option:</p><form action='./change.php' method='post'><select name='Kill' id='Kill'>";
-						for($i = 0; $i < count($OPTIONS); $i++)
-						{
-							echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
-						}
-						echo "</select><input TYPE='submit' id='cmdSubmit' VALUE='Delete Option'/></form>";
-				}
-			?>
+							for($i = 0; $i < count($OPTIONS); $i++)
+							{
+								//Trying to work on split, at this point for the few times this is used, a list is good
+								echo "<div id='selection_of_options" . 0 . "'>";
+								echo 	"<input type='checkbox' value=" . $OPTIONS_ID[$i] . " onclick='change_option(" . $OPTIONS_ID[$i];
+								
+								$result = mysql_query("SELECT `disabled` FROM `Types` WHERE `index`='" . $OPTIONS_ID[$i] . "'");
+								
+								if($result)
+								{
+									$row = mysql_fetch_array($result);
+									if ($row['disabled'] == "0")
+									{
+										echo ",0)' checked";
+									}else{
+										echo ",1)' ";
+									}
+								}else{
+									echo ")' ";
+								}
+								
+								echo "/>" . $OPTIONS[$i] . "";
+								echo "</div>";
+							}
+							
+							
+							echo "<p>New Option:</p><form action='./change.php' method='post'>
+								<input class='input_box' type='text' name='New_term' id='New_term'/>
+							<input TYPE='submit' id='cmdSubmit' VALUE='New Option'/></form>";
+							
+							
+							echo "<p>Delete Option:</p><form action='./change.php' method='post'><select name='Kill' id='Kill'>";
+							for($i = 0; $i < count($OPTIONS); $i++)
+							{
+								echo "<option value=" . $OPTIONS_ID[$i] . ">" . $OPTIONS[$i] . "</option>";
+							}
+							echo "</select><input TYPE='submit' id='cmdSubmit' VALUE='Delete Option'/></form>";
+					}
+				?>
 			<hr>
 			<div id="footer">
 				<div id="Stats">					
-				<?PHP 
-					if (phpCAS::isAuthenticated())
-					{
-						echo "<a href='./logout.php' class='labels'>Logout " . phpCAS::getUser() . "</a>";
-					}else
-					{
-						echo "<a href='./login.php' class='labels'>Login</a>";
-					}
-					if ($Customize || $admin) { echo "<p style='margin:0;'><a href='./settings.php' class='labels'>Settings</a></p>"; }
-					
-					QuickLogs::db_disconnect();
-				?>	
+					<?PHP 
+						if (phpCAS::isAuthenticated())
+						{
+							echo "<a href='./logout.php' class='labels'>Logout " . phpCAS::getUser() . "</a>";
+						}else
+						{
+							echo "<a href='./login.php' class='labels'>Login</a>";
+						}
+						if ($Customize || $admin) { echo "<p style='margin:0;'><a href='./settings.php' class='labels'>Settings</a></p>"; }
+						
+						QuickLogs::db_disconnect();
+						?>	
 				</div>
 				<div id="version">v<?PHP echo QuickLogs::get_version(); ?> <a href="https://github.com/daberkow/QuickLogs">Source</a></a></div>
 				<div id="switch_ver">
-					<a href="http://j2ee7.server.rpi.edu:8080/helpdesk/stylesheets/welcome.faces" class="labels"> Send in a Ticket </a>
+					<a href="http://leet.arc.rpi.edu/forum" class="labels"> Send in a Ticket </a>
 					<p style="margin: 0;"><a href="./stats.php" class="labels">See Stats</a></p>
 				</div>
 			</div>

--- a/lite/stats.php
+++ b/lite/stats.php
@@ -1,9 +1,9 @@
 <?PHP
 	// Dan Berkowitz, berkod2@rpi.edu, dansberkowitz@gmail.com, Feb 2012
+	// Updated from PHP 5 to PHP 7, Joshua Rosenfeld, rosenj5@rpi.edu, jomaxro@gmail.com, Jan 2017
 	include '../core.php';
-
-?>
-
+	
+	?>
 <html>
 	<head>
 		<title class = "title">QuickLogs</title>
@@ -17,7 +17,9 @@
 		<div id="main">
 			<div id="title">
 				<div class="logo"></div>
-				<a href="./index.php"><div id="logo">QuickLogs</div></a>
+				<a href="./index.php">
+					<div id="logo">QuickLogs</div>
+				</a>
 				<div id="result"></div>
 			</div>
 			<div class="red_bar"></div>
@@ -26,23 +28,16 @@
 			<div style='display: inline;'><input type="radio" name="group2" value="30" checked onchange='makeChart()'> 30 Days <input type="radio" name="group2" value="90" onchange='makeChart()'> 90 Days <input type="radio" name="group2" value="365" onchange='makeChart()'> 365 Days <input type="radio" name="group2" value="all" onchange='makeChart()'> All Time </div>
 			<!--<div><input type="radio" name="group2" value="pick">Start Date:<input type='text' style='width:15%' id='startField'/>End Date:<input style='width:15%' type='text' id='endField'/></div>-->
 			<div id="container" style='width: 100%; height: 400px;'>
-				
 			</div>
 			<div id="container2" style='width: 100%; height: 400px;'>
-				
 			</div>
 			<div id="container3" style='width: 100%; height: 400px;'>
-				
 			</div>
 			<div id="container5" style='width: 100%; height: 400px;'>
-				
 			</div>
 			<div id="container4" style='width: 100%; height: 400px;'>
-				
 			</div>
 			<p style='font-weight: bold; text-align:center;'><img src='./excel.png' alt='Download in Excel' height='24' width='24' /> Download Database in Excel  <a href="./chart.php?chart=excel_6months">6 Months,</a>  <a href="./chart.php?chart=excel_12months">1 Year,</a>  <a href="./chart.php?chart=excel_all">Entire Database</a></p>
-			 
-			
 			<div id="footer">
 				<?PHP include("./footer.php"); ?>
 			</div>

--- a/lite/submit.php
+++ b/lite/submit.php
@@ -1,27 +1,28 @@
 <?PHP
 	// Dan Berkowitz, berkod2@rpi.edu, dansberkowitz@gmail.com, Feb 2012
+	// Updated from PHP 5 to PHP 7, Joshua Rosenfeld, rosenj5@rpi.edu, jomaxro@gmail.com, Jan 2017
 	//Submit handles when jobs are sent in as done, and options changing
-
+	
 	include '../core.php';
-
+	
 	//Inserting a log into the log table
 	if(isset($_REQUEST['Task_ID']))
 	{
-		QuickLogs::db_connect();
+		$mysqli = mysqli_connect("localhost", "root", "bacon", "QuickLogs") or die("Could Not Connect To MYSQL or DATABASE");
 	
 		if (phpCAS::isAuthenticated())
 		{
-			$result = mysql_query("INSERT INTO `QuickLogs`.`Logs` (`timestamp`, `type`, `userid`) VALUES ((SELECT UNIX_TIMESTAMP()), " . $_REQUEST['Task_ID'] . ", (SELECT `ID` FROM `Users` WHERE `username`='" . phpCAS::getUser() . "' LIMIT 1))");
+			$result = mysqli_query($mysqli, "INSERT INTO `QuickLogs`.`Logs` (`timestamp`, `type`, `userid`) VALUES ((SELECT UNIX_TIMESTAMP()), " . $_REQUEST['Task_ID'] . ", (SELECT `ID` FROM `Users` WHERE `username`='" . phpCAS::getUser() . "' LIMIT 1))");
 		}else{
-			$result = mysql_query("INSERT INTO `QuickLogs`.`Logs` (`timestamp`, `type`, `userid`) VALUES ((SELECT UNIX_TIMESTAMP()), " . $_REQUEST['Task_ID'] . ", 0);");
+			$result = mysqli_query($mysqli, "INSERT INTO `QuickLogs`.`Logs` (`timestamp`, `type`, `userid`) VALUES ((SELECT UNIX_TIMESTAMP()), " . $_REQUEST['Task_ID'] . ", 0);");
 		}
 		//The default user is user 0, this means user 0 HAS to be blank
 		if($result)
 		{
-			$new_result = mysql_query("SELECT COUNT(*) AS RecordNumber FROM `Logs`");
+			$new_result = mysqli_query($mysqli, "SELECT COUNT(*) AS RecordNumber FROM `Logs`");
 			if ($new_result)
 			{
-				$row = mysql_fetch_array($new_result);
+				$row = mysqli_fetch_array($new_result);
 				echo "Recorded, entry: #" . $row['RecordNumber'];
 			}else{
 				echo "Recorded.";
@@ -34,25 +35,25 @@
 	{
 		if (isset($_REQUEST['Box1']) AND isset($_REQUEST['Box2']) AND isset($_REQUEST['Box3']) AND isset($_REQUEST['Box4']) AND isset($_REQUEST['Box5']) AND isset($_REQUEST['Box6']) AND isset($_REQUEST['Box7']) AND isset($_REQUEST['Box8']) AND isset($_REQUEST['Box9']) AND isset($_REQUEST['Box10']))
 		{
-			QuickLogs::db_connect();
+			$mysqli = mysqli_connect("localhost", "root", "bacon", "QuickLogs") or die("Could Not Connect To MYSQL or DATABASE");
 			
 			if(isset($_REQUEST['Admin']) AND phpCAS::isAuthenticated())
 			{
-				$admin_check = mysql_query("SELECT `type` FROM `Users` WHERE `username`='" . phpCAS::getUser() . "'");
+				$admin_check = mysqli_query($mysqli, "SELECT `type` FROM `Users` WHERE `username`='" . phpCAS::getUser() . "'");
 				if ($admin_check)
 				{
-					$row = mysql_fetch_array($admin_check);
+					$row = mysqli_fetch_array($admin_check);
 					if ($row['type'] == "1")
 					{
-						$result = mysql_query("UPDATE `QuickLogs`.`display` SET `Box1`='" . $_REQUEST['Box1'] . "', `Box2`='" . $_REQUEST['Box2'] . "', `Box3`='" . $_REQUEST['Box3'] . "', `Box4`='" . $_REQUEST['Box4'] . "', `Box5`='" . $_REQUEST['Box5'] . "', `Box6`='" . $_REQUEST['Box6'] . "', `Box7`='" . $_REQUEST['Box7'] . "', `Box8`='" . $_REQUEST['Box8'] . "', `Box9`='" . $_REQUEST['Box9'] . "', `Box10`='" . $_REQUEST['Box10'] . "' WHERE `user`=0");
+						$result = mysqli_query($mysqli, "UPDATE `QuickLogs`.`display` SET `Box1`='" . $_REQUEST['Box1'] . "', `Box2`='" . $_REQUEST['Box2'] . "', `Box3`='" . $_REQUEST['Box3'] . "', `Box4`='" . $_REQUEST['Box4'] . "', `Box5`='" . $_REQUEST['Box5'] . "', `Box6`='" . $_REQUEST['Box6'] . "', `Box7`='" . $_REQUEST['Box7'] . "', `Box8`='" . $_REQUEST['Box8'] . "', `Box9`='" . $_REQUEST['Box9'] . "', `Box10`='" . $_REQUEST['Box10'] . "' WHERE `user`=0");
 						
 						if ($_POST['Customize_On'])
 						{
-							mysql_query("UPDATE `QuickLogs`.`Settings` SET `Active`='0' WHERE `setting`='1'");
+							mysqli_query($mysqli, "UPDATE `QuickLogs`.`Settings` SET `Active`='0' WHERE `setting`='1'");
 						}else{
-							mysql_query("UPDATE `QuickLogs`.`Settings` SET `Active`='1' WHERE `setting`='1'");
+							mysqli_query($mysqli, "UPDATE `QuickLogs`.`Settings` SET `Active`='1' WHERE `setting`='1'");
 						}
-						if ($result)
+						if ($result) 
 						{
 							header("location: ./settings.php");
 						}else{
@@ -61,12 +62,12 @@
 					}else{
 						echo "PERMISSION DENIED";
 					}
-				}			
+				}
 			}
 	
 			if (phpCAS::isAuthenticated() AND !isset($_REQUEST['Admin'])) // this should be true
 			{
-				$result = mysql_query("UPDATE `QuickLogs`.`display` SET `Box1`='" . $_REQUEST['Box1'] . "', `Box2`='" . $_REQUEST['Box2'] . "', `Box3`='" . $_REQUEST['Box3'] . "', `Box4`='" . $_REQUEST['Box4'] . "', `Box5`='" . $_REQUEST['Box5'] . "', `Box6`='" . $_REQUEST['Box6'] . "', `Box7`='" . $_REQUEST['Box7'] . "', `Box8`='" . $_REQUEST['Box8'] . "', `Box9`='" . $_REQUEST['Box9'] . "', `Box10`='" . $_REQUEST['Box10'] . "' WHERE `user`=(SELECT `ID` FROM `Users` WHERE `username`='" . phpCAS::getUser() . "' LIMIT 1)");
+				$result = mysqli_query($mysqli, "UPDATE `QuickLogs`.`display` SET `Box1`='" . $_REQUEST['Box1'] . "', `Box2`='" . $_REQUEST['Box2'] . "', `Box3`='" . $_REQUEST['Box3'] . "', `Box4`='" . $_REQUEST['Box4'] . "', `Box5`='" . $_REQUEST['Box5'] . "', `Box6`='" . $_REQUEST['Box6'] . "', `Box7`='" . $_REQUEST['Box7'] . "', `Box8`='" . $_REQUEST['Box8'] . "', `Box9`='" . $_REQUEST['Box9'] . "', `Box10`='" . $_REQUEST['Box10'] . "' WHERE `user`=(SELECT `ID` FROM `Users` WHERE `username`='" . phpCAS::getUser() . "' LIMIT 1)");
 				if ($result)
 				{
 					header("location: ./index.php");
@@ -80,4 +81,4 @@
 			echo "Error No Data Passed";
 		}
 	}
-?>
+	?>


### PR DESCRIPTION
Ubuntu 16.04 provides PHP 7.0, where Ubuntu 14.04 and Ubuntu 12.04 came with PHP 5.x.

PHP 5.x supports 3 MySQL APIs: `ext/mysql`, `ext/mysqli`, and `PDO_MySQL`, where PHP 7.0 drops support for `ext/mysql`.  RPI_QuickLogs uses `ext/mysql` and therefore is incompatible with Unbuntu 16.04 and PHP 7.0.

These commits change the MySQL API for RPI_QuickLogs to `ext/mysqli` to support running on Ubuntu 16.04.